### PR TITLE
feat: add an option to run `make` in release-mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,34 @@
 # configuration
-TRIPLE := i686-elf
-  ARCH := x86
-  NAME := gratos
+    TRIPLE := i686-elf
+      ARCH := x86
+      NAME := gratos
+BUILD_MODE := ${if ${RELEASE},release,debug}
 
 # commands
+        MKDIR := ${shell which mkdir}
            AS := ${shell which ${TRIPLE}-as}
-           LD := ${shell which ${TRIPLE}-ld}
-      OBJDUMP := ${shell which ${TRIPLE}-objdump}
         CARGO := ${shell which cargo}
-         QEMU := ${shell which qemu-system-x86_64}
-        MKDIR := ${shell which mkdir} -p
-           CP := ${shell which cp}
-           RM := ${shell which rm} -rf
+           LD := ${shell which ${TRIPLE}-ld}
     GRUB_FILE := ${shell which grub-file}
 GRUB_MKRESCUE := ${shell which grub-mkrescue}
+         QEMU := ${shell which qemu-system-x86_64}
+           RM := ${shell which rm}
 
 # directories
        ARCH_DIR := arch/${ARCH}
         OBJ_DIR := obj
         ISO_DIR := iso
        BOOT_DIR := ${ISO_DIR}/boot
-CARGO_BUILD_DIR := target/target/debug
+CARGO_BUILD_DIR := target/target/${BUILD_MODE}
 
 # files
-     BIN := ${NAME}.${ARCH}.bin
+     BIN := ${BOOT_DIR}/${NAME}.${ARCH}.bin
      ISO := ${NAME}.${ARCH}.iso
  ASM_SRC := \
 ${addsuffix .s, \
 	start \
 }
- ASM_OBJ := ${addprefix ${OBJ_DIR}/, ${ASM_SRC:.s=.o}}
+ ASM_OBJ := ${addprefix ${OBJ_DIR}/${BUILD_MODE}/, ${ASM_SRC:.s=.o}}
 RUST_SRC := \
 ${addsuffix .rs, \
 	${addprefix src/, \
@@ -41,34 +40,30 @@ ${addsuffix .rs, \
      LIB := ${CARGO_BUILD_DIR}/lib${NAME}.a
 GRUB_CFG := ${BOOT_DIR}/grub/grub.cfg
 
-# flags
-GRUB_MKRESCUE_FLAGS := --compress=xz
-
 # rules
 .PHONY: all run clean re
 
 all: ${ISO}
 
-${OBJ_DIR}/%.o: ${ARCH_DIR}/%.s
-	${MKDIR} ${OBJ_DIR}
-	${AS} $< ${OUTPUT_OPTION}
-
-${LIB}: ${RUST_SRC}
-	${CARGO} +nightly build
+${ISO}: ${BIN}
+	${GRUB_MKRESCUE} --compress=xz ${OUTPUT_OPTION} ${ISO_DIR}
 
 ${BIN}: ${ASM_OBJ} ${LIB}
 	${LD} -T ${ARCH_DIR}/link.ld ${OUTPUT_OPTION} $^
-	${GRUB_FILE} --is-${ARCH}-multiboot ${BIN}
+	${GRUB_FILE} --is-${ARCH}-multiboot $@
 
-${ISO}: ${BIN}
-	${CP} $< ${BOOT_DIR}/$<
-	${GRUB_MKRESCUE} ${GRUB_MKRESCUE_FLAGS} ${OUTPUT_OPTION} ${ISO_DIR}
+${OBJ_DIR}/${BUILD_MODE}/%.o: ${ARCH_DIR}/%.s
+	${MKDIR} -p ${@D}
+	${AS}${if ${RELEASE},, -g} ${OUTPUT_OPTION} $<
+
+${LIB}: ${RUST_SRC}
+	${CARGO} build${if ${RELEASE}, --release}
 
 run: ${ISO}
 	${QEMU} -cdrom $<
 
 clean:
 	${CARGO} clean
-	${RM} ${OBJ_DIR} ${BOOT_DIR}/${BIN} ${BIN} ${ISO}
+	${RM} -rf ${OBJ_DIR} ${BIN} ${ISO}
 
 re: clean all


### PR DESCRIPTION
We are now able to build the project in release-mod using `make all RELEASE=<whatever_while_not_empty>`