### PR TITLE
refactor: fix clippy pedantic

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,10 @@ jobs:
       - name: cargo clippy --release
         run: |
           cargo clippy --release -- --deny warnings
+      - name: cargo clippy pedantic
+        run: |
+          cargo clippy -- --deny clippy::pedantic
+          cargo clippy --release -- --deny clippy::pedantic
 
   build:
     runs-on: ubuntu-latest

--- a/src/driver/tty/history.rs
+++ b/src/driver/tty/history.rs
@@ -1,12 +1,12 @@
-use crate::driver::vga::{ScreenChar, BUFFER_HEIGHT, BUFFER_WIDTH};
+use crate::driver::vga::{Line, Screen, ScreenChar, BUFFER_HEIGHT, BUFFER_WIDTH};
 
 use super::{DEFAULT_COLOR_CODE, HISTORY_BUFFER_HEIGHT, NUMBER_OF_REGULAR_TTY};
 
-static mut BUFFER: *mut [[[ScreenChar; BUFFER_WIDTH]; HISTORY_BUFFER_HEIGHT];
-    NUMBER_OF_REGULAR_TTY] = &mut [[[ScreenChar {
-    ascii_character: b' ',
-    color_code: DEFAULT_COLOR_CODE,
-}; BUFFER_WIDTH]; HISTORY_BUFFER_HEIGHT]; NUMBER_OF_REGULAR_TTY];
+static mut BUFFER: *mut [[Line; HISTORY_BUFFER_HEIGHT]; NUMBER_OF_REGULAR_TTY] =
+    &mut [[[ScreenChar {
+        ascii_character: b' ',
+        color_code: DEFAULT_COLOR_CODE,
+    }; BUFFER_WIDTH]; HISTORY_BUFFER_HEIGHT]; NUMBER_OF_REGULAR_TTY];
 
 #[derive(Clone, Copy)]
 struct HistoryDescriptor {
@@ -27,8 +27,8 @@ impl HistoryDescriptor {
 
 pub struct History {
     tty_id: usize,
-    history_descriptors: [HistoryDescriptor; NUMBER_OF_REGULAR_TTY],
-    chars: *mut [[[ScreenChar; BUFFER_WIDTH]; HISTORY_BUFFER_HEIGHT]; NUMBER_OF_REGULAR_TTY],
+    descriptors: [HistoryDescriptor; NUMBER_OF_REGULAR_TTY],
+    chars: *mut [[Line; HISTORY_BUFFER_HEIGHT]; NUMBER_OF_REGULAR_TTY],
 }
 
 unsafe impl Send for History {}
@@ -37,26 +37,25 @@ impl History {
     pub fn new() -> History {
         History {
             tty_id: 0,
-            history_descriptors: [HistoryDescriptor::new(); NUMBER_OF_REGULAR_TTY],
+            descriptors: [HistoryDescriptor::new(); NUMBER_OF_REGULAR_TTY],
             chars: unsafe { BUFFER },
         }
     }
 
-    pub fn set_char(&mut self, x: usize, y: usize, c: ScreenChar) {
-        if x < BUFFER_WIDTH && y < BUFFER_HEIGHT {
+    pub fn set_char(&mut self, c: &ScreenChar, col: usize, row: usize) {
+        if col < BUFFER_WIDTH && row < BUFFER_HEIGHT {
             unsafe {
                 (*self.chars)[self.tty_id]
-                    [(self.history_descriptors[self.tty_id].current + y) % HISTORY_BUFFER_HEIGHT]
-                    [x] = c;
+                    [(self.descriptors[self.tty_id].current + row) % HISTORY_BUFFER_HEIGHT][col] =
+                    *c;
             }
         }
     }
 
-    pub fn set_line(&mut self, line: [ScreenChar; BUFFER_WIDTH], y: usize) {
+    pub fn set_line(&mut self, line: &Line, row: usize) {
         unsafe {
             (*self.chars)[self.tty_id]
-                [(self.history_descriptors[self.tty_id].current + y) % HISTORY_BUFFER_HEIGHT] =
-                line;
+                [(self.descriptors[self.tty_id].current + row) % HISTORY_BUFFER_HEIGHT] = *line;
         }
     }
 
@@ -66,25 +65,25 @@ impl History {
         if x < BUFFER_WIDTH && y < BUFFER_HEIGHT {
             Ok(unsafe {
                 (*self.chars)[self.tty_id]
-                    [(self.history_descriptors[self.tty_id].current + y) % HISTORY_BUFFER_HEIGHT][x]
+                    [(self.descriptors[self.tty_id].current + y) % HISTORY_BUFFER_HEIGHT][x]
             })
         } else {
             Err(())
         }
     }
 
-    pub fn get_line(&self, y: usize) -> Result<[ScreenChar; BUFFER_WIDTH], ()> {
+    pub fn get_line(&self, y: usize) -> Result<Line, ()> {
         if y < BUFFER_HEIGHT {
             Ok(unsafe {
                 (*self.chars)[self.tty_id]
-                    [(self.history_descriptors[self.tty_id].current + y) % HISTORY_BUFFER_HEIGHT]
+                    [(self.descriptors[self.tty_id].current + y) % HISTORY_BUFFER_HEIGHT]
             })
         } else {
             Err(())
         }
     }
 
-    pub fn get_screen(&self) -> [[ScreenChar; BUFFER_WIDTH]; BUFFER_HEIGHT] {
+    pub fn get_screen(&self) -> Screen {
         let mut screen = [[ScreenChar {
             ascii_character: b' ',
             color_code: DEFAULT_COLOR_CODE,
@@ -92,57 +91,52 @@ impl History {
         for (i, s) in screen.iter_mut().enumerate() {
             unsafe {
                 *s = (*self.chars)[self.tty_id]
-                    [(self.history_descriptors[self.tty_id].current + i) % HISTORY_BUFFER_HEIGHT];
+                    [(self.descriptors[self.tty_id].current + i) % HISTORY_BUFFER_HEIGHT];
             }
         }
         screen
     }
 
     pub fn previous_line(&mut self) -> Result<(), ()> {
-        if self.history_descriptors[self.tty_id].begin
-            != self.history_descriptors[self.tty_id].current
-        {
-            self.history_descriptors[self.tty_id].current -= 1;
-            Ok(())
-        } else {
+        if self.descriptors[self.tty_id].begin == self.descriptors[self.tty_id].current {
             Err(())
+        } else {
+            self.descriptors[self.tty_id].current -= 1;
+            Ok(())
         }
     }
 
     pub fn next_line(&mut self) -> Result<(), ()> {
-        if self.history_descriptors[self.tty_id].current
-            != self.history_descriptors[self.tty_id].end
-        {
-            self.history_descriptors[self.tty_id].current += 1;
-            Ok(())
-        } else {
+        if self.descriptors[self.tty_id].current == self.descriptors[self.tty_id].end {
             Err(())
+        } else {
+            self.descriptors[self.tty_id].current += 1;
+            Ok(())
         }
     }
 
     pub fn new_line(&mut self) {
-        self.history_descriptors[self.tty_id].end =
-            (self.history_descriptors[self.tty_id].end + 1) % HISTORY_BUFFER_HEIGHT;
-        self.history_descriptors[self.tty_id].current = self.history_descriptors[self.tty_id].end;
-        if (self.history_descriptors[self.tty_id].end + BUFFER_HEIGHT - 1) % HISTORY_BUFFER_HEIGHT
-            == self.history_descriptors[self.tty_id].begin
+        self.descriptors[self.tty_id].end =
+            (self.descriptors[self.tty_id].end + 1) % HISTORY_BUFFER_HEIGHT;
+        self.descriptors[self.tty_id].current = self.descriptors[self.tty_id].end;
+        if (self.descriptors[self.tty_id].end + BUFFER_HEIGHT - 1) % HISTORY_BUFFER_HEIGHT
+            == self.descriptors[self.tty_id].begin
         {
-            self.history_descriptors[self.tty_id].begin =
-                (self.history_descriptors[self.tty_id].begin + 1) % HISTORY_BUFFER_HEIGHT;
+            self.descriptors[self.tty_id].begin =
+                (self.descriptors[self.tty_id].begin + 1) % HISTORY_BUFFER_HEIGHT;
         }
         let new_line = [ScreenChar {
             ascii_character: b' ',
             color_code: DEFAULT_COLOR_CODE,
         }; BUFFER_WIDTH];
         unsafe {
-            (*self.chars)[self.tty_id][(self.history_descriptors[self.tty_id].end
-                + BUFFER_HEIGHT
-                - 1)
-                % HISTORY_BUFFER_HEIGHT] = new_line;
+            (*self.chars)[self.tty_id]
+                [(self.descriptors[self.tty_id].end + BUFFER_HEIGHT - 1) % HISTORY_BUFFER_HEIGHT] =
+                new_line;
         }
     }
 
-    pub fn change_tty(&mut self, id: usize) -> Result<(), ()> {
+    pub fn change_tty_id(&mut self, id: usize) -> Result<(), ()> {
         if id < NUMBER_OF_REGULAR_TTY && self.tty_id != id {
             self.tty_id = id;
             Ok(())

--- a/src/driver/vga/mod.rs
+++ b/src/driver/vga/mod.rs
@@ -45,3 +45,6 @@ pub struct ScreenChar {
     pub ascii_character: u8,
     pub color_code: ColorCode,
 }
+
+pub type Line = [ScreenChar; BUFFER_WIDTH];
+pub type Screen = [Line; BUFFER_HEIGHT];

--- a/src/driver/vga/text_mode.rs
+++ b/src/driver/vga/text_mode.rs
@@ -1,9 +1,9 @@
-use super::{ScreenChar, BUFFER_HEIGHT, BUFFER_WIDTH};
+use super::{Line, Screen, ScreenChar, BUFFER_WIDTH};
 use crate::io::outb;
 
 #[repr(transparent)]
 struct Buffer {
-    chars: [[ScreenChar; BUFFER_WIDTH]; BUFFER_HEIGHT],
+    chars: Screen,
 }
 
 unsafe impl Send for Writer {}
@@ -19,19 +19,20 @@ impl Writer {
         }
     }
 
-    pub fn set_char(&mut self, c: ScreenChar, col: usize, row: usize) {
-        unsafe { (*self.buffer).chars[row][col] = c };
+    pub fn set_char(&mut self, c: &ScreenChar, col: usize, row: usize) {
+        unsafe { (*self.buffer).chars[row][col] = *c };
     }
 
-    pub fn set_line(&mut self, line: [ScreenChar; BUFFER_WIDTH], row: usize) {
-        unsafe { (*self.buffer).chars[row] = line };
+    pub fn set_line(&mut self, line: &Line, row: usize) {
+        unsafe { (*self.buffer).chars[row] = *line };
     }
 
-    pub fn set_screen(&mut self, screen: [[ScreenChar; BUFFER_WIDTH]; BUFFER_HEIGHT]) {
-        unsafe { (*self.buffer).chars = screen };
+    pub fn set_screen(&mut self, screen: &Screen) {
+        unsafe { (*self.buffer).chars = *screen };
     }
 }
 
+#[allow(clippy::cast_possible_truncation)]
 pub fn set_cursor(col: usize, row: usize) {
     let pos = (row * BUFFER_WIDTH + col) as u16;
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -6,7 +6,7 @@ pub unsafe extern "C" fn memcpy(dest: *mut c_void, src: *const c_void, n: c_size
 
     while i < n {
         unsafe {
-            *(dest as *mut c_char).wrapping_add(i) = *(src as *const c_char).wrapping_add(i);
+            *dest.cast::<c_char>().wrapping_add(i) = *src.cast::<c_char>().wrapping_add(i);
         }
         i += 1;
     }
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn memmove(
     src: *const c_void,
     n: c_size_t,
 ) -> *mut c_void {
-    if (dest as *const c_void) < src {
+    if dest.cast_const() < src {
         unsafe { memcpy(dest, src, n) }
     } else {
         let mut i: c_size_t = n;
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn memmove(
         while 0 < i {
             i -= 1;
             unsafe {
-                *(dest as *mut c_char).wrapping_add(i) = *(src as *const c_char).wrapping_add(i);
+                *dest.cast::<c_char>().wrapping_add(i) = *src.cast::<c_char>().wrapping_add(i);
             }
         }
         dest
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn memset(dest: *mut c_void, c: c_int, n: c_size_t) -> *mu
 
     while i < n {
         unsafe {
-            *(dest as *mut c_char).wrapping_add(i) = c as c_char;
+            *dest.cast::<c_char>().wrapping_add(i) = (c & 0xFF) as c_char;
         }
         i += 1;
     }
@@ -52,12 +52,11 @@ pub unsafe extern "C" fn memcmp(s1: *const c_void, s2: *const c_void, n: c_size_
     let mut i: c_size_t = 0;
 
     while i < n {
-        let diff = unsafe {
-            *(s1 as *const c_char).wrapping_add(i) - *(s2 as *const c_char).wrapping_add(i)
-        };
+        let diff =
+            unsafe { *s1.cast::<c_char>().wrapping_add(i) - *s2.cast::<c_char>().wrapping_add(i) };
 
         if diff != 0 {
-            return diff as c_int;
+            return c_int::from(diff);
         }
         i += 1;
     }


### PR DESCRIPTION
I activate clippy in pedantic mode to help us code in a "clean" way,
errors can be ignored if they are justified