### PR TITLE
feat: add basic commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,25 +64,25 @@ qemu-system-x86_64 -cdrom gratos.x86.iso
     - [x] Handle different screens, and keyboard shortcuts to switch easily between then.
 - [ ] KFS-2 (gratOS:0.2.0):
   - [ ] Mandatory:
-    - [ ] create a Global Descriptor Table
-    - [ ] Your GDT must contain:
-      - [ ] Kernel Code
-      - [ ] Kernel Data
-      - [ ] Kernel stack
-      - [ ] User code
-      - [ ] User data
-      - [ ] User stack
+    - [x] create a Global Descriptor Table
+    - [x] Your GDT must contain:
+      - [x] Kernel Code
+      - [x] Kernel Data
+      - [x] Kernel stack
+      - [x] User code
+      - [x] User data
+      - [x] User stack
     - [ ] Your work must not exceed 10 MB.
-    - [ ] You must declare your GDT to the BIOS.
-    - [ ] The GDT must be set at address 0x00000800.
-    - [ ] When this is done, you have to code a tool to print the kernel stack, in a human-friendly way. (Tip: If you haven’t made a printk yet, now is a good time !)
-  - [ ] Bonus:
+    - [x] You must declare your GDT to the BIOS.
+    - [x] The GDT must be set at address 0x00000800.
+    - [x] When this is done, you have to code a tool to print the kernel stack, in a human-friendly way. (Tip: If you haven’t made a printk yet, now is a good time !)
+  - [x] Bonus:
     - [x] Assuming your keyboard work correctly in your Kernel, and you able to catch an entry, let’s code a Shell !
         Not a POSIX Shell, just a minimalistic shell with a few commands, for debugging purposes.
     - [x] For example, you could implement the print-kernel-stack-thing in this shell, and some other things like reboot, halt and such.
       - [x] hello
-      - [ ] print-kernel-stack-thing
-      - [ ] reboot
-      - [ ] halt
+      - [x] print-kernel-stack-thing
+      - [x] reboot
+      - [x] halt
 - [x] Other:
   - [x] add CI to build and serve an iso of gratOS

--- a/src/driver/shell/halt.rs
+++ b/src/driver/shell/halt.rs
@@ -1,0 +1,8 @@
+use core::arch::asm;
+
+#[allow(dead_code)]
+pub fn halt() {
+    unsafe {
+        asm!("hlt",);
+    }
+}

--- a/src/driver/shell/mod.rs
+++ b/src/driver/shell/mod.rs
@@ -76,7 +76,7 @@ impl Shell {
         } else if compare_command(b"reboot", &self.command) {
             reboot::reboot();
         } else if compare_command(b"shutdown", &self.command) {
-            shutdown::shutdown_qemu();
+            shutdown::qemu();
         } else {
             println!("command not found");
         }

--- a/src/driver/shell/mod.rs
+++ b/src/driver/shell/mod.rs
@@ -1,4 +1,9 @@
+mod halt;
 mod hello;
+mod print_gdt;
+mod print_kernel_stack;
+mod reboot;
+mod shutdown;
 
 use spin::{Lazy, Mutex};
 
@@ -62,6 +67,16 @@ impl Shell {
     fn process(&mut self) {
         if compare_command(b"hello", &self.command) {
             hello::hello();
+        } else if compare_command(b"halt", &self.command) {
+            halt::halt();
+        } else if compare_command(b"print_gdt", &self.command) {
+            print_gdt::print_gdt();
+        } else if compare_command(b"print_kernel_stack", &self.command) {
+            print_kernel_stack::print_kernel_stack(0);
+        } else if compare_command(b"reboot", &self.command) {
+            reboot::reboot();
+        } else if compare_command(b"shutdown", &self.command) {
+            shutdown::shutdown_qemu();
         } else {
             println!("command not found");
         }

--- a/src/driver/shell/print_gdt.rs
+++ b/src/driver/shell/print_gdt.rs
@@ -1,0 +1,161 @@
+use crate::driver;
+use crate::println;
+use core::arch::asm;
+
+struct SegmentDescriptor {
+    base: u32,
+    limit: u32,
+    flags: u8,
+    access_byte: u8,
+}
+
+// Function which parses the segment descriptor
+// Elements of a segment descriptor are quite scattered
+// so we need to combine them to get the actual values
+fn parse_segment_descriptor(descriptor: u64) -> SegmentDescriptor {
+    // The base address is split into 3 parts
+    // The bits from 16 to 31 are the first 16 bits of the base address
+    // The bits from 32 to 39 are the next 8 bits of the base address
+    // and the bits from 56 to 63 are the last 8 bits of the base address
+    let base = ((descriptor >> 16) & 0xFFFF) as u32
+        | (((descriptor >> 32) & 0xFF) as u32) << 16
+        | (((descriptor >> 56) & 0xFF) as u32) << 24;
+
+    // The limit is split into 2 parts
+    // The bits from 0 to 15 are the first 16 bits of the limit
+    // The bits from 48 to 51 are the next 4 bits of the limit
+    let limit = ((descriptor & 0xFFFF) as u32) | (((descriptor >> 48) & 0xF) as u32) << 16;
+
+    // The flags are the bits from 52 to 55
+    let flags = ((descriptor >> 52) & 0xF) as u8;
+
+    // The access byte is the bits from 40 to 47
+    let access_byte = ((descriptor >> 40) & 0xFF) as u8;
+
+    SegmentDescriptor {
+        base,
+        limit,
+        flags,
+        access_byte,
+    }
+}
+
+fn describe_flags(flags: u8) {
+    let granularity = if (flags & 0b1000) != 0 { "4KB" } else { "1B" };
+    let size = if (flags & 0b0100) != 0 {
+        "32-bit"
+    } else {
+        "16-bit"
+    };
+    let long_mode = if (flags & 0b0010) != 0 {
+        "64-bit"
+    } else {
+        "Legacy"
+    };
+    let reserved = if (flags & 0b0001) != 0 {
+        "Reserved"
+    } else {
+        "Unused"
+    };
+
+    println!(
+        "+-------------+---------+-----------+----------+\n\
+         | Granularity | Size    | Long Mode | Reserved |\n\
+         +-------------+---------+-----------+----------+\n\
+         | {:<11} | {:<7} | {:<9} | {:<8} |\n\
+         +-------------+---------+-----------+----------+",
+        granularity, size, long_mode, reserved
+    );
+}
+
+fn check_bit(byte: u8, bit: u8) -> bool {
+    (byte & (1 << bit)) != 0
+}
+
+fn describe_access_byte(access_byte: u8) {
+    let accessed = check_bit(access_byte, 0);
+    let readable_or_writable = check_bit(access_byte, 1);
+    let direction_or_conforming = check_bit(access_byte, 2);
+    let executable = check_bit(access_byte, 3);
+    let descriptor_type = if check_bit(access_byte, 4) {
+        "Code/Data"
+    } else {
+        "System"
+    };
+    let dpl = (access_byte & 0b0110_0000) >> 5;
+    let present = check_bit(access_byte, 7);
+
+    println!(
+        "+----------+-------------------+-----------------------+------------+\n\
+         | Accessed | Readable/Writable | Direction/Conforming  | Executable |\n\
+         +----------+-------------------+-----------------------+------------+\n\
+         | {:<8} | {:<17} | {:<21} | {:<10} |\n\
+         +----------+-------------------+-----------------------+------------+\n\
+         +-----------------+----------------+--------------+\n\
+         | Descriptor Type | DPL            |   Present    |\n\
+         +-----------------+----------------+--------------+\n\
+         | {:<15} | {:<14} | {:<12} |\n\
+         +-----------------+----------------+--------------+",
+        accessed,
+        readable_or_writable,
+        direction_or_conforming,
+        executable,
+        descriptor_type,
+        dpl,
+        present
+    );
+}
+
+fn print_segment(segment: &SegmentDescriptor, index: u16) {
+    println!(
+        "{}+-------------------------+\n\
+             |       Segment {:<9} |\n\
+             +-------------------------+{}",
+        driver::console::FG_BLUE,
+        index,
+        driver::console::RESET
+    );
+    println!("Base: {:#X}", segment.base);
+    println!("Limit: {:#X}", segment.limit);
+    describe_flags(segment.flags);
+    describe_access_byte(segment.access_byte);
+}
+
+fn print_base(base: u16) {
+    println!(
+        "{}Base: {:#010X}{}",
+        driver::console::FG_BRIGHT_CYAN,
+        base,
+        driver::console::RESET
+    );
+}
+
+fn print_limit(limit: u16) {
+    println!(
+        "{}Limit: {:#010X}{}",
+        driver::console::FG_BRIGHT_CYAN,
+        limit,
+        driver::console::RESET
+    );
+}
+
+pub fn print_gdt() {
+    let mut gdt = [0; 2];
+    unsafe {
+        asm!("sgdt [{}]", in(reg) &mut gdt);
+    }
+    let gdt_base = gdt[1];
+    let gdt_limit = gdt[0];
+    print_base(gdt_base);
+    print_limit(gdt_limit);
+
+    let mut gdt_ptr = gdt_base as *const u64;
+    let gdt_limit = gdt_limit / 8 + 1;
+
+    for i in 0..gdt_limit {
+        let gdt_entry = unsafe { *gdt_ptr };
+        let segment = parse_segment_descriptor(gdt_entry);
+        print_segment(&segment, i);
+        gdt_ptr = unsafe { gdt_ptr.offset(1) };
+    }
+}

--- a/src/driver/shell/print_kernel_stack.rs
+++ b/src/driver/shell/print_kernel_stack.rs
@@ -2,6 +2,7 @@ use crate::print;
 use core::arch::asm;
 
 #[cfg(debug_assertions)]
+#[allow(dead_code)]
 pub fn test() {
     #[allow(unused_variables)]
     let alphabet = [

--- a/src/driver/shell/reboot.rs
+++ b/src/driver/shell/reboot.rs
@@ -1,0 +1,8 @@
+use core::arch::asm;
+
+#[allow(dead_code)]
+pub fn reboot() {
+    unsafe {
+        asm!("lea eax, [1b]", "push eax", "retf",);
+    }
+}

--- a/src/driver/shell/shutdown.rs
+++ b/src/driver/shell/shutdown.rs
@@ -2,7 +2,7 @@ use crate::io::outw;
 use core::arch::asm;
 
 #[allow(dead_code)]
-pub fn shutdown_qemu() {
+pub fn qemu() {
     unsafe {
         asm!("cli",);
         outw(0x2000, 0x604);

--- a/src/driver/shell/shutdown.rs
+++ b/src/driver/shell/shutdown.rs
@@ -1,0 +1,10 @@
+use crate::io::outw;
+use core::arch::asm;
+
+#[allow(dead_code)]
+pub fn shutdown_qemu() {
+    unsafe {
+        asm!("cli",);
+        outw(0x2000, 0x604);
+    }
+}

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -27,7 +27,7 @@ pub fn init() {
         *GDT = [
             SegmentDescriptor::null(),                // Null segment
             SegmentDescriptor::new(0, 0xFFFFF, 0x9A), // Kernel code segment
-            SegmentDescriptor::new(0, 0xFFFFF, 0x92), // Kernel data segment
+            SegmentDescriptor::new(0, 0xFFFFF, 0x93), // Kernel data segment
             SegmentDescriptor::new(0, 0xFFFFF, 0x96), // Kernel stack segment
             SegmentDescriptor::new(0, 0xFFFFF, 0xFA), // User code segment
             SegmentDescriptor::new(0, 0xFFFFF, 0xF2), // User data segment

--- a/src/io.rs
+++ b/src/io.rs
@@ -25,3 +25,14 @@ pub unsafe fn outb(value: u8, port: u16) {
         );
     }
 }
+
+#[allow(dead_code)]
+pub unsafe fn outw(value: u16, port: u16) {
+    unsafe {
+        asm!(
+            "out dx, ax",
+            in("ax") value,
+            in("dx") port
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 mod driver;
 mod gdt;
 mod io;
-mod print_kernel_stack;
 mod string;
 
 use core::panic::PanicInfo;
@@ -28,12 +27,7 @@ pub extern "C" fn kmain() -> ! {
     #[cfg(debug_assertions)]
     console::test_colors();
 
-    #[cfg(debug_assertions)]
-    print_kernel_stack::test();
-
     println!("{}42{}", console::FG_GREEN, console::FG_RESET);
-
-    print_kernel_stack::print_kernel_stack(0);
 
     let mut keyboard = keyboard::ps2::Keyboard::new();
 


### PR DESCRIPTION
both commands added to a module commands. Could be relevant to move print kernel stack there as well.
The reboot command jump to the label created in the initial assembly.
The halt command runs hlt.
Shutdown send a shutdown to qemu so works only on qemu since shutdown is a power management action, it is specific to the hardware.